### PR TITLE
feature/typed_var

### DIFF
--- a/kua/routes.py
+++ b/kua/routes.py
@@ -318,17 +318,20 @@ class Routes:
                 if self._ROUTE_NODE not in curr:
                     continue
 
-                route_match = curr[self._ROUTE_NODE]
-                params = make_params(
-                    key_parts=route_match.key_parts,
-                    variable_parts=curr_variable_parts)
+                for route in curr[self._ROUTE_NODE]:  # todo: move elsewhere
+                    params = make_params(
+                        key_parts=route.key_parts,
+                        variable_parts=curr_variable_parts)
 
-                if not validate(params, route_match.validate):
+                    # todo: decode variables before validating
+                    if not validate(params, route.validate):
+                        continue
+
+                    return RouteResolved(
+                        params=params,
+                        anything=route.anything)
+                else:  # no-break
                     continue
-
-                return RouteResolved(
-                    params=params,
-                    anything=route_match.anything)
 
             if self._VAR_ANY_NODE in curr:
                 to_visit.append((
@@ -409,9 +412,11 @@ class Routes:
             curr_partial_routes = (
                 curr_partial_routes.setdefault(part, {}))
 
-        curr_partial_routes[self._ROUTE_NODE] = _route(
+        (curr_partial_routes
+         .setdefault(self._ROUTE_NODE, [])
+         .append(_route(
             key_parts=curr_key_parts,
             anything=anything,
-            validate=validate)
+            validate=validate)))
 
         self._max_depth = max(self._max_depth, depth_of(parts))

--- a/kua/routes.py
+++ b/kua/routes.py
@@ -201,7 +201,7 @@ class Routes:
 
         # Typed vars
         is_num = lambda part: part.isdigit()
-        self.routes.add('api/user/:id', {'GET': my_get_controller}, {'id': is_num})
+        routes.add('api/user/:id', {'GET': my_get_controller}, {'id': is_num})
         route = routes.match('api/user/123')
         route.params
         # {'id': '123'}

--- a/kua/routes.py
+++ b/kua/routes.py
@@ -275,7 +275,7 @@ class Routes:
 
     _VAR_ANY_BREAK = ':*var:break'
 
-    def __init__(self, max_depth: int=40) -> None:
+    def __init__(self, max_depth: int=10) -> None:
         """
         :ivar _routes: \
         Contain a graph with the parts of\

--- a/kua/routes.py
+++ b/kua/routes.py
@@ -67,7 +67,7 @@ def normalize_url(url: str) -> str:
 def decode_parts(parts):
     try:
         return tuple(
-            urllib.parse.unquote_plus(
+            urllib.parse.unquote(
                 part, encoding='utf-8', errors='strict')
             for part in parts)
     except UnicodeDecodeError:

--- a/tests/tests_routes.py
+++ b/tests/tests_routes.py
@@ -299,12 +299,10 @@ class KuaTest(unittest.TestCase):
         """
         Should validate clashing vars
         """
-        # todo: support clashing urls!
-
         self.routes.add(':var', 'foo', {'var': is_int})
         self.routes.add(':var', 'bar', {'var': is_alphanum})
 
-        self.assertEqual(self.routes.match('123').anything, 'bar')  # fixme: should == foo
+        self.assertEqual(self.routes.match('123').anything, 'foo')
         self.assertEqual(self.routes.match('foo123').anything, 'bar')
 
     def test_any_var_validate(self):

--- a/tests/tests_routes.py
+++ b/tests/tests_routes.py
@@ -9,6 +9,14 @@ from kua import routes
 logging.disable(logging.CRITICAL)
 
 
+def is_int(var):
+    return var.isdigit()
+
+
+def is_alphanum(var):
+    return var.isalnum()
+
+
 class KuaTest(unittest.TestCase):
 
     def setUp(self):
@@ -262,9 +270,6 @@ class KuaTest(unittest.TestCase):
         """
         Should validate a var
         """
-        def is_int(var):
-            return var.isdigit()
-
         self.routes.add(':var', 'foo', {'var': is_int})
 
         route = self.routes.match('123')
@@ -277,12 +282,6 @@ class KuaTest(unittest.TestCase):
         """
         Should validate a many vars
         """
-        def is_alphanum(var):
-            return var.isalnum()
-
-        def is_int(var):
-            return var.isdigit()
-
         self.routes.add(':var/:var2/:var3', 'foo', {'var': is_int, 'var2': is_alphanum})
 
         route = self.routes.match('123/foo123/bar123---')
@@ -296,12 +295,6 @@ class KuaTest(unittest.TestCase):
         """
         Should validate clashing vars
         """
-        def is_alphanum(var):
-            return var.isalnum()
-
-        def is_int(var):
-            return var.isdigit()
-
         # todo: support clashing urls!
 
         self.routes.add(':var', 'foo', {'var': is_int})
@@ -317,9 +310,6 @@ class KuaTest(unittest.TestCase):
         def is_each(func):
             return lambda vars_: all(func(var) for var in vars_)
 
-        def is_int(var):
-            return var.isdigit()
-
         self.routes.add(':*var', 'foo', {'var': is_each(is_int)})
 
         route = self.routes.match('123/456/789')
@@ -332,9 +322,6 @@ class KuaTest(unittest.TestCase):
         """
         Should raise an error when validate params don't match pattern params
         """
-        def is_int(var):
-            return var.isdigit()
-
         self.assertRaises(
             routes.RouteError, self.routes.add, ':var', 'foo', {'bad': is_int})
         self.assertRaises(

--- a/tests/tests_routes.py
+++ b/tests/tests_routes.py
@@ -347,3 +347,21 @@ class KuaTest(unittest.TestCase):
         self.assertEqual(self.routes.match('foo/bar').anything, 'qux')
         self.assertEqual(self.routes.match('static/123/123').anything, 'quux')
         self.assertEqual(self.routes.match('static/foo/foo').anything, 'quuz')
+
+    def test_I10L(self):
+        """
+        Should support I10L letters within components
+        """
+        self.routes.add('i10l/áéíóú/áéíóú', 'foo')
+        self.assertEqual(self.routes.match(
+            'i10l/%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA/%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA').anything, 'foo')
+
+    def test_treat_plus_as_plus(self):
+        """
+        Should treat plus signs as plus signs
+        """
+        self.routes.add('foo+bar', 'foo')
+        self.assertEqual(self.routes.match('foo+bar').anything, 'foo')
+
+        self.routes.add('á+á', 'bar')
+        self.assertEqual(self.routes.match('%C3%A1+%C3%A1').anything, 'bar')

--- a/tests/tests_routes.py
+++ b/tests/tests_routes.py
@@ -303,7 +303,9 @@ class KuaTest(unittest.TestCase):
         self.routes.add(':var', 'bar', {'var': is_alphanum})
 
         self.assertEqual(self.routes.match('123').anything, 'foo')
+        self.assertEqual(self.routes.match('123').params, {'var': '123'})
         self.assertEqual(self.routes.match('foo123').anything, 'bar')
+        self.assertEqual(self.routes.match('foo123').params, {'var': 'foo123'})
 
     def test_any_var_validate(self):
         """


### PR DESCRIPTION
This feature was described in comments of #2 

* Adds var validators
* Adds support for I10L URLs, mostly coz validating on a encoded string does not make much sense
* Adds support for clashing URLs
* *Breaking change*: on clashing URLs first added URL will match. Previous to this last added URL would had match.

Usage:

```python
is_num = lambda part: part.isdigit()
routes.add('api/user/:id', {'GET': my_get_controller}, {'id': is_num})
route = routes.match('api/user/123')
route.params
# {'id': '123'}

route = routes.match('api/user/bad')
# Raises RouteError
```
