### PR TITLE
Prevents bundling 'tests' dir in wheels, etc.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='ecastroborsani@gmail.com',
     long_description=README,
     url=URL,
-    packages=find_packages(exclude=[]),
+    packages=find_packages(exclude=['tests*', 'kua.tests*']),
     test_suite="runtests.start",
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
This is important for contexts like Serverless, where the `tests` dir would collide with the consumer repo's `tests` dir.

See https://github.com/PyMySQL/PyMySQL/issues/705 for more detail of this kind of problem.